### PR TITLE
Includes of sick_lms200 adjusted in kurt_base and kurt_description

### DIFF
--- a/kurt_base/urdf/rotunit.urdf.xacro
+++ b/kurt_base/urdf/rotunit.urdf.xacro
@@ -8,6 +8,7 @@
   <include filename="$(find uos_common_urdf)/common.xacro" />
 
   <include filename="$(find uos_common_urdf)/urdf/sick_lms200.urdf.xacro" />
+  <xacro:sick_lms200 laser_link="laser" /> 
 
   <xacro:property name="rotunit_box_x" value="0.18" />
   <xacro:property name="rotunit_box_y" value="0.18" />

--- a/kurt_description/tops/kurt2_top.urdf.xacro
+++ b/kurt_description/tops/kurt2_top.urdf.xacro
@@ -3,6 +3,7 @@
   xmlns:xacro="http://ros.org/wiki/xacro">
 
   <include filename="$(find uos_common_urdf)/urdf/sick_lms200.urdf.xacro" />
+  <xacro:sick_lms200 laser_link="laser" />
 
   <link name="laptop_structure">
     <visual>


### PR DESCRIPTION
Adjusted includes of sick_lms200 in kurt urdfs in accordance with the macro introduction in the sick_lms200 urdf file. They now define the link name of the sick_lms200.
